### PR TITLE
Fix lint warning "Unnecessary escape character"

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function parseZone1970 () {
     const [countryCodes, coordinates, code, comments] = record
     return acc.concat({
       countryCodes: countryCodes.split(','),
-      coordinates: coordinates.match(/([-\+]\d+)/g),
+      coordinates: coordinates.match(/([-+]\d+)/g),
       code,
       comments: comments || ''
     })


### PR DESCRIPTION
After this fix runs the `npm runt lint` warnintg-free.